### PR TITLE
Standardise all supply commands to use the word supply

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteSupplyOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteSupplyOrderCommand.java
@@ -2,8 +2,7 @@ package seedu.address.logic.commands;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.order.OrderList;
-import seedu.address.model.order.SupplierOrderList;
+import seedu.address.model.order.SupplyOrderList;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
@@ -29,15 +28,15 @@ public class DeleteSupplyOrderCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        SupplierOrderList supplierOrderList = model.getSupplierOrderList();
+        SupplyOrderList supplyOrderList = model.getSupplyOrderList();
 
-        if (targetIndex <= 0 || targetIndex > supplierOrderList.getOrders().size()) {
+        if (targetIndex <= 0 || targetIndex > supplyOrderList.getOrders().size()) {
             throw new CommandException(MESSAGE_INVALID_INDEX);
         }
 
-        String phoneNumber = supplierOrderList.getOrderByIndex(targetIndex - 1).getPhoneNumber();
+        String phoneNumber = supplyOrderList.getOrderByIndex(targetIndex - 1).getPhoneNumber();
 
-        supplierOrderList.removeOrder(phoneNumber);
+        supplyOrderList.removeOrder(phoneNumber);
 
         return new CommandResult(String.format(MESSAGE_DELETE_SUPPLY_ORDER_SUCCESS, targetIndex));
     }

--- a/src/main/java/seedu/address/logic/commands/MarkSupplyOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkSupplyOrderCommand.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.order.SupplyOrder;
-import seedu.address.model.order.SupplierOrderList;
+import seedu.address.model.order.SupplyOrderList;
 import seedu.address.model.order.OrderStatus;
 import seedu.address.model.product.Ingredient;
 import seedu.address.model.product.Inventory;
@@ -11,35 +11,35 @@ import seedu.address.model.product.Product;
 
 import java.util.List;
 
-public class MarkSupplierOrderCommand extends Command {
-    public static final String COMMAND_WORD = "markSupplierOrder";
+public class MarkSupplyOrderCommand extends Command {
+    public static final String COMMAND_WORD = "markSupplyOrder";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Marks the supplier order at the given index as completed and updates the inventory.\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Marks the supply order at the given index as completed and updates the inventory.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_MARK_ORDER_SUCCESS = "Marked supplier order as completed: %1$s";
+    public static final String MESSAGE_MARK_ORDER_SUCCESS = "Marked supply order as completed: %1$s";
     public static final String MESSAGE_ORDER_ALREADY_COMPLETED = "The order at index %1$s is already completed.";
     public static final String MESSAGE_INVALID_INDEX = "The index provided is invalid.";
 
     private final int targetIndex;
 
-    public MarkSupplierOrderCommand(int targetIndex) {
+    public MarkSupplyOrderCommand(int targetIndex) {
         this.targetIndex = targetIndex;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        SupplierOrderList supplierOrderList = model.getSupplierOrderList();
+        SupplyOrderList supplyOrderList = model.getSupplyOrderList();
         Inventory inventory = model.getInventory();  // Get inventory from the model
 
         // Validate index
-        if (targetIndex <= 0 || targetIndex > supplierOrderList.getOrders().size()) {
+        if (targetIndex <= 0 || targetIndex > supplyOrderList.getOrders().size()) {
             throw new CommandException(MESSAGE_INVALID_INDEX);
         }
 
         // Retrieve the supplier order at the target index
-        SupplyOrder supplyOrder = supplierOrderList.getOrders().get(targetIndex - 1);
+        SupplyOrder supplyOrder = supplyOrderList.getOrders().get(targetIndex - 1);
 
         // Check if the order is already completed
         if (supplyOrder.getStatus() == OrderStatus.COMPLETED) {
@@ -58,8 +58,8 @@ public class MarkSupplierOrderCommand extends Command {
         // Mark the order as completed
         supplyOrder.setStatus(OrderStatus.COMPLETED);
 
-        supplierOrderList.removeOrder(supplyOrder.getPhoneNumber());
-        supplierOrderList.addOrder(supplyOrder);
+        supplyOrderList.removeOrder(supplyOrder.getPhoneNumber());
+        supplyOrderList.addOrder(supplyOrder);
 
         return new CommandResult(String.format(MESSAGE_MARK_ORDER_SUCCESS, targetIndex));
     }
@@ -67,7 +67,7 @@ public class MarkSupplierOrderCommand extends Command {
     @Override
     public boolean equals(Object other) {
         return other == this
-                || (other instanceof MarkSupplierOrderCommand
-                && targetIndex == ((MarkSupplierOrderCommand) other).targetIndex);
+                || (other instanceof MarkSupplyOrderCommand
+                && targetIndex == ((MarkSupplyOrderCommand) other).targetIndex);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewOrderListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewOrderListCommand.java
@@ -18,7 +18,7 @@ public class ViewOrderListCommand extends Command {
         String result = "Customer Orders: \n"
                         + model.getCustomerOrderList().viewOrders()
                         + "Supply Orders: \n"
-                        + model.getSupplierOrderList().viewOrders();
+                        + model.getSupplyOrderList().viewOrders();
         return new CommandResult(result);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -127,7 +127,7 @@ public class AddressBookParser {
         case MarkCustomerOrderCommand.COMMAND_WORD:
             return new MarkCustomerOrderCommandParser().parse(arguments);
 
-        case MarkSupplierOrderCommand.COMMAND_WORD:
+        case MarkSupplyOrderCommand.COMMAND_WORD:
             return new MarkSupplierOrderCommandParser().parse(arguments);
 
         default:

--- a/src/main/java/seedu/address/logic/parser/MarkSupplierOrderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkSupplierOrderCommandParser.java
@@ -1,14 +1,14 @@
 package seedu.address.logic.parser;
 
-import seedu.address.logic.commands.MarkSupplierOrderCommand;
+import seedu.address.logic.commands.MarkSupplyOrderCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
-public class MarkSupplierOrderCommandParser implements Parser<MarkSupplierOrderCommand> {
+public class MarkSupplierOrderCommandParser implements Parser<MarkSupplyOrderCommand> {
     @Override
-    public MarkSupplierOrderCommand parse(String args) throws ParseException {
+    public MarkSupplyOrderCommand parse(String args) throws ParseException {
         try {
             int index = Integer.parseInt(args.trim());
-            return new MarkSupplierOrderCommand(index);
+            return new MarkSupplyOrderCommand(index);
         } catch (NumberFormatException e) {
             throw new ParseException(String.format("Invalid index: %s", args));
         }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -17,7 +17,7 @@ import seedu.address.model.person.UniquePersonList;
 public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniquePersonList persons;
-    private final SupplierOrderList supplyOrders;
+    private final SupplyOrderList supplyOrders;
     private final CustomerOrderList customerOrders;
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
@@ -28,7 +28,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     {
         persons = new UniquePersonList();
-        supplyOrders = new SupplierOrderList();
+        supplyOrders = new SupplyOrderList();
         customerOrders = new CustomerOrderList();
     }
 
@@ -119,7 +119,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         return customerOrders;
     }
 
-    public SupplierOrderList getSupplierOrderList() {
+    public SupplyOrderList getSupplierOrderList() {
         return supplyOrders;
     }
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -7,7 +7,7 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.order.CustomerOrder;
 import seedu.address.model.order.CustomerOrderList;
-import seedu.address.model.order.SupplierOrderList;
+import seedu.address.model.order.SupplyOrderList;
 import seedu.address.model.order.SupplyOrder;
 import seedu.address.model.person.Person;
 import seedu.address.model.product.*;
@@ -109,7 +109,7 @@ public interface Model {
 
     CustomerOrderList getCustomerOrderList();
 
-    SupplierOrderList getSupplierOrderList();
+    SupplyOrderList getSupplyOrderList();
 
     Inventory getInventory();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -13,7 +13,6 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.order.*;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.Supplier;
 import seedu.address.model.product.Ingredient;
 import seedu.address.model.product.IngredientCatalogue;
 import seedu.address.model.product.Pastry;
@@ -31,7 +30,7 @@ public class ModelManager implements Model {
     private final FilteredList<Person> filteredPersons;
     private final PastryCatalogue pastryCatalogue = new PastryCatalogue();
     private final IngredientCatalogue ingredientCatalogue = new IngredientCatalogue();
-    private final SupplierOrderList supplierOrderList;
+    private final SupplyOrderList supplyOrderList;
     private final CustomerOrderList customerOrderList;
     private final ObservableList<SupplyOrder> supplyOrderObservableList;
     private final ObservableList<CustomerOrder> customerOrderObservableList;
@@ -49,9 +48,9 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         this.filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
-        this.supplierOrderList = this.addressBook.getSupplierOrderList();
+        this.supplyOrderList = this.addressBook.getSupplierOrderList();
         this.customerOrderList = this.addressBook.getCustomerOrderList();
-        this.supplyOrderObservableList = this.supplierOrderList.getOrders();
+        this.supplyOrderObservableList = this.supplyOrderList.getOrders();
         this.customerOrderObservableList = this.customerOrderList.getOrders();
     }
 
@@ -150,7 +149,7 @@ public class ModelManager implements Model {
 
     @Override
     public void addSupplyOrder(SupplyOrder supplyOrder) {
-        supplierOrderList.addOrder(supplyOrder);
+        supplyOrderList.addOrder(supplyOrder);
     }
 
     @Override
@@ -159,8 +158,8 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public SupplierOrderList getSupplierOrderList() {
-        return supplierOrderList;
+    public SupplyOrderList getSupplyOrderList() {
+        return supplyOrderList;
     }
 
     public ObservableList<SupplyOrder> getSupplyOrderObservableList() {

--- a/src/main/java/seedu/address/model/order/SupplierOrderList.java
+++ b/src/main/java/seedu/address/model/order/SupplierOrderList.java
@@ -1,7 +1,0 @@
-package seedu.address.model.order;
-
-public class SupplierOrderList extends OrderList<SupplyOrder> {
-    public SupplierOrderList() {
-        super();
-    }
-}

--- a/src/main/java/seedu/address/model/order/SupplyOrderList.java
+++ b/src/main/java/seedu/address/model/order/SupplyOrderList.java
@@ -1,0 +1,7 @@
+package seedu.address.model.order;
+
+public class SupplyOrderList extends OrderList<SupplyOrder> {
+    public SupplyOrderList() {
+        super();
+    }
+}


### PR DESCRIPTION
Easier to standardise that all commands inputted into the CLI is using the word "supply"

Changes:
markSupplierOrder -> markSupplyOrder
deleteSupplierOrder -> deleteSupplyOrder
SupplierOrderList -> SupplyOrderList

Supplier is reserved to refer to the Supplier class that inherits person
