### PR TITLE
Change Order class to have two person fields and fix bug in addcustomerorder/addsupplyorder commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCustomerOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCustomerOrderCommand.java
@@ -56,6 +56,13 @@ public class AddCustomerOrderCommand extends Command {
 
         PastryCatalogue pastryCatalogue = model.getPastryCatalogue();
 
+        // Check if all product IDs exist in the catalogue
+        for (Integer id : idList) {
+            if (pastryCatalogue.getProductById(id) == null) {
+                throw new CommandException("One or more specified pastries do not exist in the pastry catalogue.");
+            }
+        }
+
         List<Product> productList = idList.stream()
                                         .map(pastryCatalogue::getProductById)
                                         .filter(Objects::nonNull)

--- a/src/main/java/seedu/address/logic/commands/AddSupplyOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddSupplyOrderCommand.java
@@ -56,6 +56,13 @@ public class AddSupplyOrderCommand extends Command {
 
         IngredientCatalogue ingredientCatalogue = model.getIngredientCatalogue();
 
+        // Check if all product IDs exist in the catalogue
+        for (Integer id : idList) {
+            if (ingredientCatalogue.getProductById(id) == null) {
+                throw new CommandException("One or more specified ingredients do not exist in the ingredient catalogue.");
+            }
+        }
+
         List<Product> productList = idList.stream()
                                         .map(ingredientCatalogue::getProductById)
                                         .filter(Objects::nonNull)

--- a/src/main/java/seedu/address/logic/commands/DeleteCustomerOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCustomerOrderCommand.java
@@ -42,7 +42,7 @@ public class DeleteCustomerOrderCommand extends Command {
 
         Order order = customerOrderList.getOrder(targetIndex - 1);
 
-        Person person = order.getPerson();
+        Person person = order.getOriginalPerson();
         person.removeOrder(order);
 
         customerOrderList.removeOrder(targetIndex - 1);

--- a/src/main/java/seedu/address/logic/commands/DeleteCustomerOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCustomerOrderCommand.java
@@ -4,7 +4,9 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.order.CustomerOrder;
 import seedu.address.model.order.CustomerOrderList;
+import seedu.address.model.person.Person;
 
 /**
  * Deletes a customer order at the specified index.
@@ -37,6 +39,13 @@ public class DeleteCustomerOrderCommand extends Command {
         if (targetIndex <= 0 || targetIndex > customerOrderList.getOrders().size()) {
             throw new CommandException(MESSAGE_INVALID_INDEX);
         }
+
+        // Retrieve the customer order
+        CustomerOrder customerOrder = customerOrderList.getOrders().get(targetIndex - 1);
+
+        // Remove the order from the person's order list
+        Person person = customerOrder.getPerson();
+        person.removeOrder(customerOrder);
 
         customerOrderList.removeOrder(targetIndex - 1);
 

--- a/src/main/java/seedu/address/logic/commands/DeleteSupplyOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteSupplyOrderCommand.java
@@ -38,7 +38,7 @@ public class DeleteSupplyOrderCommand extends Command {
         }
 
         Order order = supplyOrderList.getOrder(targetIndex - 1);
-        order.getPerson().removeOrder(order);
+        order.getOriginalPerson().removeOrder(order);
 
         supplyOrderList.removeOrder(targetIndex - 1);
         return new CommandResult(String.format(MESSAGE_DELETE_SUPPLY_ORDER_SUCCESS, targetIndex));

--- a/src/main/java/seedu/address/logic/commands/DeleteSupplyOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteSupplyOrderCommand.java
@@ -4,7 +4,9 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.order.SupplyOrder;
 import seedu.address.model.order.SupplyOrderList;
+import seedu.address.model.person.Person;
 
 /**
  * Deletes a supply order at the specified index.
@@ -35,6 +37,13 @@ public class DeleteSupplyOrderCommand extends Command {
         if (targetIndex <= 0 || targetIndex > supplyOrderList.getOrders().size()) {
             throw new CommandException(MESSAGE_INVALID_INDEX);
         }
+
+        // Retrieve the supply order
+        SupplyOrder supplyOrder = supplyOrderList.getOrders().get(targetIndex - 1);
+
+        // Remove the order from the person's order list
+        Person person = supplyOrder.getPerson();
+        person.removeOrder(supplyOrder);
 
         supplyOrderList.removeOrder(targetIndex - 1);
         return new CommandResult(String.format(MESSAGE_DELETE_SUPPLY_ORDER_SUCCESS, targetIndex));

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -147,12 +147,11 @@ public class ModelManager implements Model {
         addressBook.setPerson(target, editedPerson);
     }
 
-    //Initialise the orders with the correct person object in the address book
     public void associateOrdersWithPersons() {
         for (CustomerOrder customerOrder : customerOrderList.getOrders()) {
             addressBook.findPersonByPhone(customerOrder.getPerson().getPhone())
                     .ifPresent(person -> {
-                        customerOrder.setPerson(person);
+                        customerOrder.setOriginalPerson(person);
                         person.addOrder(customerOrder);
                     });
         }
@@ -160,7 +159,7 @@ public class ModelManager implements Model {
         for (SupplyOrder supplyOrder : supplyOrderList.getOrders()) {
             addressBook.findPersonByPhone(supplyOrder.getPerson().getPhone())
                     .ifPresent(person -> {
-                        supplyOrder.setPerson(person);
+                        supplyOrder.setOriginalPerson(person);
                         person.addOrder(supplyOrder);
                     });
         }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -147,15 +147,22 @@ public class ModelManager implements Model {
         addressBook.setPerson(target, editedPerson);
     }
 
+    //Initialise the orders with the correct person object in the address book
     public void associateOrdersWithPersons() {
         for (CustomerOrder customerOrder : customerOrderList.getOrders()) {
             addressBook.findPersonByPhone(customerOrder.getPerson().getPhone())
-                    .ifPresent(person -> person.addOrder(customerOrder));
+                    .ifPresent(person -> {
+                        customerOrder.setPerson(person);
+                        person.addOrder(customerOrder);
+                    });
         }
 
         for (SupplyOrder supplyOrder : supplyOrderList.getOrders()) {
             addressBook.findPersonByPhone(supplyOrder.getPerson().getPhone())
-                    .ifPresent(person -> person.addOrder(supplyOrder));
+                    .ifPresent(person -> {
+                        supplyOrder.setPerson(person);
+                        person.addOrder(supplyOrder);
+                    });
         }
     }
 

--- a/src/main/java/seedu/address/model/order/Order.java
+++ b/src/main/java/seedu/address/model/order/Order.java
@@ -17,6 +17,7 @@ public abstract class Order {
     private final List<? extends Product> items;
     private OrderStatus status;
     private final Person person;
+    private Person originalPerson;
     private final Remark remark;
 
     /**
@@ -31,7 +32,8 @@ public abstract class Order {
         this.orderDate = LocalDateTime.now();
         this.items = items;
         this.status = status;
-        this.person = person;
+        this.person = new Person(person);
+        this.originalPerson = person;
         this.remark = remark;
     }
 
@@ -42,6 +44,14 @@ public abstract class Order {
      */
     public Person getPerson() {
         return person;
+    }
+
+    public Person getOriginalPerson() {
+        return originalPerson;
+    }
+
+    public void setOriginalPerson(Person person) {
+        this.originalPerson = person;
     }
 
     /**

--- a/src/main/java/seedu/address/model/order/Order.java
+++ b/src/main/java/seedu/address/model/order/Order.java
@@ -15,7 +15,7 @@ public abstract class Order {
     private final LocalDateTime orderDate;
     private final List<? extends Product> items;
     private OrderStatus status;
-    private final Person person;
+    private Person person;
 
     /**
      * Constructs an {@code Order} with the specified customer, list of items, and initial status.
@@ -39,6 +39,10 @@ public abstract class Order {
      */
     public Person getPerson() {
         return person;
+    }
+
+    public void setPerson(Person person) {
+        this.person = person;
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -52,6 +52,16 @@ public class Person {
         this.tags.addAll(tags);
     }
 
+    // Copy constructor
+    public Person(Person person) {
+        this.name = person.name;
+        this.phone = person.phone;
+        this.email = person.email;
+        this.address = person.address;
+        this.remark = person.remark;
+        this.tags.addAll(person.tags);
+    }
+
     /**
      * Retrieves the orders associated with this person as a formatted string.
      *


### PR DESCRIPTION
This pull request introduces changes to the Order class to store two Person objects: originalPerson referencing the same Person object in the AddressBook and person as a copy. This ensures that when a Person is deleted from the AddressBook, the Order objects still retain a copy of the Person details.  

Note:  When the order is initialised during app start and the person who ordered does not exist in the addressbook, originalPerson field will contain a copy of person rather than a pointer.

- Updated `AddCustomerOrderCommand` to check that all product IDs exist in the `PastryCatalogue` before creating an order.
- Updated `AddSupplyOrderCommand` to check that all product IDs exist in the `IngredientCatalogue` before creating an order.
- Throw a `CommandException` if any product ID does not exist in the respective catalogues.
- Ensured that the application handles invalid product IDs gracefully by providing appropriate error messages.
