### PR TITLE
Make information field optional for adding a customer and improve display messages

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -5,7 +5,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.parser.Prefix;
+import seedu.address.model.person.Customer;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Supplier;
 
 /**
  * Container for user visible messages.
@@ -36,15 +38,29 @@ public class Messages {
      */
     public static String format(Person person) {
         final StringBuilder builder = new StringBuilder();
-        builder.append(person.getName())
-                .append("; Phone: ")
-                .append(person.getPhone())
-                .append("; Email: ")
-                .append(person.getEmail())
-                .append("; Address: ")
-                .append(person.getAddress())
-                .append("; Tags: ");
+        builder.append("\n")
+                .append("Name: ")
+                .append(person.getName()).append("\n")
+                .append("Phone: ")
+                .append(person.getPhone()).append("\n")
+                .append("Email: ")
+                .append(person.getEmail()).append("\n")
+                .append("Address: ")
+                .append(person.getAddress()).append("\n")
+                .append("Tags: ")
+                .append("\n");
         person.getTags().forEach(builder::append);
+        // Check if the person is a Customer and append the information
+        if (person instanceof Customer) {
+            Customer customer = (Customer) person;
+            builder.append("Information: ").append(customer.getInformation()).append("\n");
+        }
+
+        // Check if the person is a Supplier and append the ingredients supplied
+        if (person instanceof Supplier) {
+            Supplier supplier = (Supplier) person;
+            builder.append("Ingredients Supplied: ").append(supplier.getIngredientsSupplied()).append("\n");
+        }
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddCustomerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCustomerCommand.java
@@ -27,7 +27,7 @@ public class AddCustomerCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
-            + PREFIX_INFORMATION + "INFORMATION "
+            + "[" + PREFIX_INFORMATION + "INFORMATION ]"
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "

--- a/src/main/java/seedu/address/logic/parser/AddCustomerCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCustomerCommandParser.java
@@ -48,7 +48,7 @@ public class AddCustomerCommandParser implements Parser<AddCustomerCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).orElse(null));
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).orElse(null));
-        Information information = ParserUtil.parseInformation(argMultimap.getValue(PREFIX_INFORMATION).orElse(null));
+        Information information = ParserUtil.parseInformation(argMultimap.getValue(PREFIX_INFORMATION).orElse(""));
         Remark remark = new Remark(""); // No direct remark input
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 


### PR DESCRIPTION
Make information field optional for adding a customer and improve display formatting

- Update `AddCustomerCommand` and `AddCustomerCommandParser` to make the information field optional when adding a customer.
- Modify `Messages.format` to include better formatting with newline characters for improved readability.
- Add structured and indented display for customer information and supplier ingredients.

