### PR TITLE
Fix storage for ingredient catalogue and prevent adding duplicates

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddIngredientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddIngredientCommand.java
@@ -42,7 +42,7 @@ public class AddIngredientCommand extends Command {
 
         // Use the existing ingredient catalogue from the model
         IngredientCatalogue ingredientCatalogue = model.getIngredientCatalogue();
-        int nextProductId = model.getNextProductId();
+        int nextProductId = ingredientCatalogue.getNextProductId();
 
         // Create a new ingredient with the next available product ID
         Ingredient newIngredient = new Ingredient(nextProductId, name, cost);
@@ -67,8 +67,7 @@ public class AddIngredientCommand extends Command {
                 .filter(product -> product instanceof Ingredient) // Filter only Ingredient objects
                 .map(product -> (Ingredient) product)             // Cast to Ingredient
                 .anyMatch(existingIngredient ->
-                        existingIngredient.getName().equalsIgnoreCase(newIngredient.getName()) &&
-                                Double.compare(existingIngredient.getCost(), newIngredient.getCost()) == 0);
+                        existingIngredient.getName().equalsIgnoreCase(newIngredient.getName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddPastryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPastryCommand.java
@@ -71,9 +71,7 @@ public class AddPastryCommand extends Command {
                 .filter(product -> product instanceof Pastry)
                 .map(product -> (Pastry) product)
                 .anyMatch(existingPastry ->
-                        existingPastry.getName().equalsIgnoreCase(newPastry.getName())
-                                && Double.compare(existingPastry.getCost(), newPastry.getCost()) == 0
-                                && existingPastry.getIngredients().equals(newPastry.getIngredients()));
+                        existingPastry.getName().equalsIgnoreCase(newPastry.getName()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -124,12 +124,6 @@ public interface Model {
      */
     IngredientCatalogue getIngredientCatalogue();
 
-    /**
-     * Returns the next available product ID.
-     * @return The next product ID as an integer.
-     */
-    int getNextProductId();
-
     //=========== Order Management ========================================================================
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -17,11 +17,7 @@ import seedu.address.model.order.CustomerOrderList;
 import seedu.address.model.order.SupplyOrder;
 import seedu.address.model.order.SupplyOrderList;
 import seedu.address.model.person.Person;
-import seedu.address.model.product.Ingredient;
-import seedu.address.model.product.IngredientCatalogue;
-import seedu.address.model.product.Inventory;
-import seedu.address.model.product.Pastry;
-import seedu.address.model.product.PastryCatalogue;
+import seedu.address.model.product.*;
 import seedu.address.storage.Storage;
 import seedu.address.storage.StorageManager;
 import seedu.address.model.product.Catalogue;
@@ -228,12 +224,7 @@ public class ModelManager implements Model {
 
     @Override
     public IngredientCatalogue getIngredientCatalogue() {
-        return IngredientCatalogue.getInstance();
-    }
-
-    @Override
-    public int getNextProductId() {
-        return Catalogue.nextProductId;
+        return ingredientCatalogue;
     }
 
     //=========== Order Management Methods ==================================================================

--- a/src/main/java/seedu/address/model/product/Catalogue.java
+++ b/src/main/java/seedu/address/model/product/Catalogue.java
@@ -10,7 +10,7 @@ import java.util.NoSuchElementException;
  */
 public abstract class Catalogue {
     protected final Map<Integer, Product> productCatalogue = new HashMap<>();
-    public int nextProductId = 1;
+    protected int nextProductId = 1;
 
     /**
      * Retrieves a product by its unique ID.


### PR DESCRIPTION
Ingredients and pastries with the same name should not be added, even if they have different costs (or ingredients used for pastries).