### PR TITLE
Fix markSupplyOrder, addSupplier and remark commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MarkSupplyOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkSupplyOrderCommand.java
@@ -52,6 +52,7 @@ public class MarkSupplyOrderCommand extends Command {
 
         List<? extends Product> items = supplyOrder.getItems();
 
+        /* Remove if we decide to scrap inventory
         // Filter to ensure we only process Ingredient
         for (Product product : items) {
             if (product instanceof Ingredient ingredient) {
@@ -59,6 +60,7 @@ public class MarkSupplyOrderCommand extends Command {
                 inventory.addStock(ingredient.getProductId(), 1);
             }
         }
+        */
 
         // Mark the order as completed
         supplyOrder.setStatus(OrderStatus.COMPLETED);

--- a/src/main/java/seedu/address/logic/commands/MarkSupplyOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkSupplyOrderCommand.java
@@ -52,16 +52,6 @@ public class MarkSupplyOrderCommand extends Command {
 
         List<? extends Product> items = supplyOrder.getItems();
 
-        /* Remove if we decide to scrap inventory
-        // Filter to ensure we only process Ingredient
-        for (Product product : items) {
-            if (product instanceof Ingredient ingredient) {
-                // Add stock to inventory, currently assume quantity is one
-                inventory.addStock(ingredient.getProductId(), 1);
-            }
-        }
-        */
-
         // Mark the order as completed
         supplyOrder.setStatus(OrderStatus.COMPLETED);
 

--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -54,13 +54,11 @@ public class RemarkCommand extends Command {
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
-        Person editedPerson = new Person(personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
-                personToEdit.getAddress(), remark, personToEdit.getTags());
+        personToEdit.setRemark(remark);
 
-        model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        return new CommandResult(generateSuccessMessage(editedPerson));
+        return new CommandResult(generateSuccessMessage(personToEdit));
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -27,7 +27,7 @@ public class Person {
 
     // Data fields
     private final Address address;
-    private final Remark remark;
+    private Remark remark;
     private final Set<Tag> tags = new HashSet<>();
     private final List<Order> orders = new ArrayList<>();
 
@@ -143,6 +143,10 @@ public class Person {
 
     public Remark getRemark() {
         return remark;
+    }
+
+    public void setRemark(Remark remark) {
+        this.remark = remark;
     }
 
     /**

--- a/src/main/java/seedu/address/model/product/IngredientCatalogue.java
+++ b/src/main/java/seedu/address/model/product/IngredientCatalogue.java
@@ -33,6 +33,19 @@ public class IngredientCatalogue extends Catalogue {
     }
 
     /**
+     * Deletes an ingredient from the catalogue by its ID.
+     *
+     * @param id The ID of the ingredient to delete.
+     */
+    @Override
+    public void deleteProduct(int id) {
+        Product product = productCatalogue.remove(id);
+        if (product instanceof Ingredient) {
+            ingredientByName.remove((product).getName().toLowerCase());
+        }
+    }
+
+    /**
      * Sets nextProductId to the highest ID in productCatalogue + 1.
      */
     private void setNextProductId() {

--- a/src/main/java/seedu/address/model/product/IngredientCatalogue.java
+++ b/src/main/java/seedu/address/model/product/IngredientCatalogue.java
@@ -41,7 +41,7 @@ public class IngredientCatalogue extends Catalogue {
     public void deleteProduct(int id) {
         Product product = productCatalogue.remove(id);
         if (product instanceof Ingredient) {
-            ingredientByName.remove((product).getName().toLowerCase());
+            ingredientByName.remove(product.getName().toLowerCase());
         }
     }
 


### PR DESCRIPTION
-Implement deleteProduct method in IngredientCatalogue to override deleteproduct method in 
  Catalogue to correctly remove ingredients from both maps instead of just one

-Remove function of markSupplyOrder that updates inventory units

-Change remark command to change remark field in person instead of creating a new person object

Fix to bugs in #307 and #318 and #326
Unable to recreate #277 after fixing above