### PR TITLE
Improve mark order message response

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MarkCustomerOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCustomerOrderCommand.java
@@ -24,7 +24,7 @@ public class MarkCustomerOrderCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_MARK_ORDER_SUCCESS = "Marked customer order as completed: %1$s";
+    public static final String MESSAGE_MARK_ORDER_SUCCESS = "Marked customer order as completed:";
     public static final String MESSAGE_ORDER_ALREADY_COMPLETED = "The order at index %1$s is already completed.";
     public static final String MESSAGE_INSUFFICIENT_STOCK = "Not enough stock to fulfill the order.";
     public static final String MESSAGE_INVALID_INDEX = "The index provided is invalid.";
@@ -51,8 +51,8 @@ public class MarkCustomerOrderCommand extends Command {
 
         List<? extends Product> items = customerOrder.getItems();
 
+        /* inventory function to remove
         Map<Integer, Integer> requiredIngredients = new HashMap<>();
-
         for (Product product : items) {
             if (product instanceof Pastry pastry) {
                 for (Ingredient ingredient : pastry.getIngredients()) {
@@ -62,11 +62,15 @@ public class MarkCustomerOrderCommand extends Command {
                 }
             }
         }
+        */
+
         customerOrder.setStatus(OrderStatus.COMPLETED);
 
         customerOrderList.removeOrder(targetIndex - 1);
         customerOrderList.addOrder(customerOrder);
-        return new CommandResult(String.format(MESSAGE_MARK_ORDER_SUCCESS, targetIndex));
+
+        String resultMessage = MESSAGE_MARK_ORDER_SUCCESS + "\n" + customerOrder.toString();
+        return new CommandResult(resultMessage);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/MarkSupplyOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkSupplyOrderCommand.java
@@ -22,7 +22,7 @@ public class MarkSupplyOrderCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_MARK_ORDER_SUCCESS = "Marked supply order as completed: %1$s";
+    public static final String MESSAGE_MARK_ORDER_SUCCESS = "Marked supply order as completed:";
     public static final String MESSAGE_ORDER_ALREADY_COMPLETED = "The order at index %1$s is already completed.";
     public static final String MESSAGE_INVALID_INDEX = "The index provided is invalid.";
 
@@ -66,7 +66,8 @@ public class MarkSupplyOrderCommand extends Command {
         supplyOrderList.removeOrder(targetIndex - 1);
         supplyOrderList.addOrder(supplyOrder);
 
-        return new CommandResult(String.format(MESSAGE_MARK_ORDER_SUCCESS, targetIndex));
+        String resultMessage = MESSAGE_MARK_ORDER_SUCCESS + "\n" + supplyOrder.toString();
+        return new CommandResult(resultMessage);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UnmarkCustomerOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCustomerOrderCommand.java
@@ -17,7 +17,7 @@ public class UnmarkCustomerOrderCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_UNMARK_ORDER_SUCCESS = "Marked customer order as pending: %1$s";
+    public static final String MESSAGE_UNMARK_ORDER_SUCCESS = "Marked customer order as pending:";
     public static final String MESSAGE_ORDER_ALREADY_PENDING = "The order at index %1$s is already pending.";
     public static final String MESSAGE_INVALID_INDEX = "The index provided is invalid.";
 
@@ -45,7 +45,9 @@ public class UnmarkCustomerOrderCommand extends Command {
 
         customerOrderList.removeOrder(targetIndex - 1);
         customerOrderList.addOrder(customerOrder);
-        return new CommandResult(String.format(MESSAGE_UNMARK_ORDER_SUCCESS, targetIndex));
+
+        String resultMessage = MESSAGE_UNMARK_ORDER_SUCCESS + "\n" + customerOrder.toString();
+        return new CommandResult(resultMessage);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/UnmarkSupplyOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkSupplyOrderCommand.java
@@ -17,7 +17,7 @@ public class UnmarkSupplyOrderCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_UNMARK_ORDER_SUCCESS = "Marked supply order as pending: %1$s";
+    public static final String MESSAGE_UNMARK_ORDER_SUCCESS = "Marked supply order as pending:";
     public static final String MESSAGE_ORDER_ALREADY_PENDING = "The order at index %1$s is already pending.";
     public static final String MESSAGE_INVALID_INDEX = "The index provided is invalid.";
 
@@ -46,7 +46,8 @@ public class UnmarkSupplyOrderCommand extends Command {
         supplyOrderList.removeOrder(targetIndex - 1);
         supplyOrderList.addOrder(supplyOrder);
 
-        return new CommandResult(String.format(MESSAGE_UNMARK_ORDER_SUCCESS, targetIndex));
+        String resultMessage = MESSAGE_UNMARK_ORDER_SUCCESS + "\n" + supplyOrder.toString();
+        return new CommandResult(resultMessage);
     }
 
     @Override


### PR DESCRIPTION
 Updated  markCustomerOrder, markSupplyOrder, unmarkCustomerOrder, and unmarkSupplyOrder commands to include a success message and an updated string representation of the order.

Fix for #325