### PR TITLE
Standardized customer and supplier commands

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -88,6 +88,40 @@ Now that BakeBuddy is running, let's add your first items. In the BakeBuddy wind
 
 ## **Contact Types**
 
+## Contact Types
+- **Contact**: Any person or entity stored in BakeBuddy's database, including customers, suppliers, and other business contacts
+- **Customer**: A person or business who purchases pastries from your bakery
+- **Supplier**: A person or business who provides ingredients or materials to your bakery
+
+## Order-Related Terms
+- **Customer Order**: A record of pastries ordered by a customer, including quantity, delivery details, and status
+- **Supply Order**: A record of ingredients ordered from a supplier, including quantity and status
+- **Order Status**:
+  - *Pending*: Order that has not been fulfilled yet
+  - *Done*: Order that has been completed and delivered/received
+
+## Product Management
+- **Pastry Catalogue**: Complete list of pastries your bakery offers, including prices and required ingredients
+- **Ingredient Catalogue**: Complete list of ingredients used in your bakery, including costs and supplier information
+- **Product ID**: Unique identifier assigned to each pastry or ingredient in the catalogues
+
+## UI Elements
+- **Index**: The number shown beside each item in a list, used for referencing items in commands
+
+## Cost Management
+- **COST**:
+  - For ingredients: Purchase price from supplier
+  - For pastries: Selling price to customer
+
+## Contact Management
+- **Filter**: Process of showing only contacts with specific tags
+- **Tag**: Label that can be applied to contacts for easy categorization (e.g., "VIP", "Wholesale", "Regular")
+- **Remark**: Additional notes about a contact 
+
+## Order Processing
+- **Mark/Unmark**: Commands to toggle the completion status of an order
+- **Clear**: Command to remove all data from the system
+
 <div markdown="block" class="alert alert-info">
 - **Contact**: Any person or entity stored in BakeBuddy's database, including customers, suppliers, and other business contacts
 - **Customer**: A person or business who purchases pastries from your bakery

--- a/docs/_sass/minima/_base.scss
+++ b/docs/_sass/minima/_base.scss
@@ -286,7 +286,7 @@ table {
     text-align: center;
   }
   .site-header:before {
-    content: "BakeBuddy";
+    content: "BakeBuddy 👨‍🍳👩‍🍳";
     font-size: 32px;
   }
 }

--- a/docs/_sass/minima/_base.scss
+++ b/docs/_sass/minima/_base.scss
@@ -286,7 +286,7 @@ table {
     text-align: center;
   }
   .site-header:before {
-    content: "BakeBuddy 👨‍🍳👩‍🍳";
+    content: "BakeBuddy";
     font-size: 32px;
   }
 }

--- a/src/main/java/seedu/address/logic/commands/AddCustomerCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCustomerCommand.java
@@ -7,14 +7,12 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_INFORMATION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
-
-import java.util.regex.Pattern;
-
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Customer;
+import seedu.address.model.person.Person;
 
 /**
  * Adds a customer to the address book.
@@ -40,11 +38,8 @@ public class AddCustomerCommand extends Command {
             + PREFIX_TAG + "loyal";
 
     public static final String MESSAGE_SUCCESS = "New customer added: %1$s";
-    public static final String MESSAGE_DUPLICATE_CUSTOMER = "This customer already exists in the address book";
-    public static final String MESSAGE_INVALID_INFORMATION = "Invalid information: "
-            + "The information field must only contain alphanumeric characters and spaces.";
-
-    private static final Pattern VALID_INFORMATION_REGEX = Pattern.compile("^[A-Za-z0-9\\s]+$");
+    public static final String MESSAGE_DUPLICATE_PHONE = "A contact in the address book already has this phone number. "
+            + "Please use a different phone number.";
 
     private final Customer toAdd;
 
@@ -60,24 +55,16 @@ public class AddCustomerCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        // Validate the 'information' field of the customer
-        if (!isValidInformation(toAdd.getInformation().value)) {
-            throw new CommandException(MESSAGE_INVALID_INFORMATION);
+        // Check for duplicate phone number across all contacts
+        for (Person person : model.getFilteredPersonList()) {
+            if (person.getPhone().equals(toAdd.getPhone())) {
+                throw new CommandException(MESSAGE_DUPLICATE_PHONE);
+            }
         }
 
-        if (model.hasPerson(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_CUSTOMER);
-        }
-
+        // Add the new customer if no duplicates are found
         model.addPerson(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
-    }
-
-    /**
-     * Checks if the given information field is valid (alphanumeric and spaces only).
-     */
-    private boolean isValidInformation(String information) {
-        return VALID_INFORMATION_REGEX.matcher(information).matches();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddCustomerOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCustomerOrderCommand.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.order.CustomerOrder;
 import seedu.address.model.order.OrderStatus;
+import seedu.address.model.person.Customer;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -31,13 +32,14 @@ public class AddCustomerOrderCommand extends Command {
             + "Parameters: "
             + "[" + PREFIX_NAME + "NAME] "
             + PREFIX_PHONE + "PHONE "
-            + PREFIX_ORDER + "PASTRYID] "
+            + PREFIX_ORDER + "PASTRYID "
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_ORDER + "1 1 2";
 
     public static final String MESSAGE_ADD_CUSTOMER_ORDER_SUCCESS = "New customer order added: \n%1$s";
+    public static final String INVALID_CUSTOMER = "This is not a customer. Add a customer contact instead.";
 
     private final Name name;
     private final Phone phone;
@@ -93,6 +95,10 @@ public class AddCustomerOrderCommand extends Command {
         if (person == null) {
             person = Person.getGuest(name, phone);
             model.addPerson(person);
+        }
+
+        if (!(person instanceof Customer)) {
+            throw new CommandException(INVALID_CUSTOMER);
         }
 
         CustomerOrder customerOrder = new CustomerOrder(person, productList, OrderStatus.PENDING, remark);

--- a/src/main/java/seedu/address/logic/commands/AddSupplierCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddSupplierCommand.java
@@ -48,10 +48,6 @@ public class AddSupplierCommand extends Command {
     public static final String MESSAGE_SUCCESS = "New supplier added: %1$s";
     public static final String MESSAGE_DUPLICATE_PHONE = "A contact in the address book already has this phone number. "
             + "Please use a different phone number.";
-    public static final String MESSAGE_DUPLICATE_EMAIL = "A contact in the address book already has this email address. "
-            + "Please use a different email address.";
-    public static final String MESSAGE_DUPLICATE_ADDRESS = "A contact in the address book already has this home address. "
-            + "Please use a different home address.";
     public static final String MESSAGE_INGREDIENT_NOT_FOUND = "Ingredient '%s' not found in the catalogue. "
             + "Please add it using the addIngredient command.";
 
@@ -94,12 +90,6 @@ public class AddSupplierCommand extends Command {
         for (Person person : model.getFilteredPersonList()) {
             if (person.getPhone().equals(toAdd.getPhone())) {
                 throw new CommandException(MESSAGE_DUPLICATE_PHONE);
-            }
-            if (person.getEmail().equals(toAdd.getEmail())) {
-                throw new CommandException(MESSAGE_DUPLICATE_EMAIL);
-            }
-            if (person.getAddress().equals(toAdd.getAddress())) {
-                throw new CommandException(MESSAGE_DUPLICATE_ADDRESS);
             }
         }
 

--- a/src/main/java/seedu/address/logic/commands/AddSupplyOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddSupplyOrderCommand.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ORDER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -106,6 +107,10 @@ public class AddSupplyOrderCommand extends Command {
 
         person.addOrder(supplyOrder);
         model.addSupplyOrder(supplyOrder);
+
+        // Update personList
+        model.setPerson(person, person);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
         return new CommandResult(String.format(MESSAGE_ADD_SUPPLY_ORDER_SUCCESS, supplyOrder.viewOrder()));
     }

--- a/src/main/java/seedu/address/logic/commands/AddSupplyOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddSupplyOrderCommand.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ORDER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/seedu/address/logic/commands/AddSupplyOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddSupplyOrderCommand.java
@@ -17,6 +17,7 @@ import seedu.address.model.order.SupplyOrder;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Supplier;
 import seedu.address.model.product.IngredientCatalogue;
 import seedu.address.model.product.Product;
 import seedu.address.model.util.Remark;
@@ -37,7 +38,8 @@ public class AddSupplyOrderCommand extends Command {
             + PREFIX_PHONE + "98765432 "
             + PREFIX_ORDER + "1 1 2";
 
-    public static final String MESSAGE_ADD_CUSTOMER_ORDER_SUCCESS = "New supply order added: \n%1$s";
+    public static final String MESSAGE_ADD_SUPPLY_ORDER_SUCCESS = "New supply order added: \n%1$s";
+    public static final String INVALID_SUPPLIER = "This is not a supplier. Add a supplier contact instead.";
 
     private final Name name;
     private final Phone phone;
@@ -96,12 +98,16 @@ public class AddSupplyOrderCommand extends Command {
             model.addPerson(person);
         }
 
+        if (!(person instanceof Supplier)) {
+            throw new CommandException(INVALID_SUPPLIER);
+        }
+
         SupplyOrder supplyOrder = new SupplyOrder(person, productList, OrderStatus.PENDING, remark);
 
         person.addOrder(supplyOrder);
         model.addSupplyOrder(supplyOrder);
 
-        return new CommandResult(String.format(MESSAGE_ADD_CUSTOMER_ORDER_SUCCESS, supplyOrder.viewOrder()));
+        return new CommandResult(String.format(MESSAGE_ADD_SUPPLY_ORDER_SUCCESS, supplyOrder.viewOrder()));
     }
 
 

--- a/src/test/java/seedu/address/logic/commands/AddSupplyOrderCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddSupplyOrderCommandTest.java
@@ -64,7 +64,7 @@ public class AddSupplyOrderCommandTest {
 
         CommandResult commandResult = addOrderCommand.execute(modelStub);
 
-        assertEquals(String.format(AddSupplyOrderCommand.MESSAGE_ADD_CUSTOMER_ORDER_SUCCESS,
+        assertEquals(String.format(AddSupplyOrderCommand.MESSAGE_ADD_SUPPLY_ORDER_SUCCESS,
                 modelStub.ordersAdded.get(0).viewOrder()), commandResult.getFeedbackToUser());
         assertEquals(1, modelStub.ordersAdded.size());
     }


### PR DESCRIPTION
Fix bugs to make information and ingredients supplied optional for add supplier command. Standardized both add customer and add supplier commands to make only the name and phone number field compulsory. I have fixed another bug to ensure that both add customer order and add supply order commands will only accept phone number contacts that are customers or suppliers respectively.